### PR TITLE
Fix the bug that a "key not found" exception happens  

### DIFF
--- a/migrate_rules.py
+++ b/migrate_rules.py
@@ -141,7 +141,7 @@ def migrate(rancher_url, rancher_api_token, cluster_id, insecure):
 
             rules = []
             for alert_rule in alert_rules["data"]:
-                if not alert_rule["creatorId"] or not alert_rule["metricRule"]:
+                if not alert_rule["creatorId"] or not alert_rule.get("metricRule"):
                     continue
                 metric_rule = alert_rule["metricRule"]
                 prometheus_expression = get_prometheus_expression(


### PR DESCRIPTION
 Fix the bug that a "key not found" exception happens because the field metricRule is optional in the rule.

Sample of the failure:
```
  File "migrate_rules.py", line 144, in migrate
    if not alert_rule["creatorId"] or not alert_rule["metricRule"]:
KeyError: 'metricRule'
```
